### PR TITLE
-P/--no-pigz option always fails because of incorrect conditional exp…

### DIFF
--- a/files/usr/sbin/zfstx
+++ b/files/usr/sbin/zfstx
@@ -77,7 +77,7 @@ local_fs=$2
 
 # Check dependencies
 which mbuffer > /dev/null 2>&1 || { echo "ERROR: 'mbuffer' is not installed."; exit 1; }
-[ -z "$pigz" ] && which pigz > /dev/null 2>&1 || { echo "ERROR: 'pigz' is not installed. Install it, or use --no-pigz."; exit 1; }
+[ -n "$pigz" ] && which pigz > /dev/null 2>&1 || { echo "ERROR: 'pigz' is not installed. Install it, or use --no-pigz."; exit 1; }
 
 # Check mandatory options
 [ -z "$remote_host" -o -z "$remote_fs" -o -z "$local_fs" ] && { usage; exit 1; }


### PR DESCRIPTION
…ression

Bash conditional expression should test for non-zero pigz variable (-n) instead for zero variable (-z) at line 80.  See: https://www.gnu.org/software/bash/manual/html_node/Bash-Conditional-Expressions.html#Bash-Conditional-Expressions

Thanks for all the work.  Love this set of utilities.